### PR TITLE
#3800: support for referenced splice files

### DIFF
--- a/FabricSpliceBaseInterface.h
+++ b/FabricSpliceBaseInterface.h
@@ -65,7 +65,8 @@ public:
   MStringArray getPortNames();
   FabricSplice::DGPort getPort(MString name);
   void saveToFile(MString fileName);
-  MStatus loadFromFile(MString fileName);
+  MStatus loadFromFile(MString fileName, bool asReferenced = false);
+  MStatus createAttributeForPort(FabricSplice::DGPort port);
   void setPortPersistence(const MString &portName, bool persistence);
   FabricSplice::DGGraph & getSpliceGraph() { return _spliceGraph; }
   void setDgDirtyEnabled(bool enabled) { _dgDirtyEnabled = enabled; }

--- a/FabricSpliceCommand.cpp
+++ b/FabricSpliceCommand.cpp
@@ -374,6 +374,7 @@ MStatus FabricSpliceCommand::doIt(const MArgList &args)
     else if(actionStr == "loadSplice")
     {
       MString fileNameStr = FabricSplice::Scripting::consumeStringArgument(scriptArgs, "fileName", "", true).c_str();
+      bool asReferenced = FabricSplice::Scripting::consumeBooleanArgument(scriptArgs, "asReferenced", false, true);
 
       int portLimit = 0;
       if(spliceMayaNodeFn.typeName() == "spliceMayaDeformer")
@@ -403,7 +404,7 @@ MStatus FabricSpliceCommand::doIt(const MArgList &args)
         fileNameStr = qFileName.toUtf8().constData();
     #endif      
       }
-      interf->loadFromFile(fileNameStr);
+      interf->loadFromFile(fileNameStr, asReferenced);
       return mayaErrorOccured();
     }
     else if(actionStr == "getPortInfo")

--- a/FabricSpliceEditorWidget.cpp
+++ b/FabricSpliceEditorWidget.cpp
@@ -251,6 +251,41 @@ FabricSpliceBaseInterface * FabricSpliceEditorWidget::getCurrentBaseInterface()
   return node;
 }
 
+void FabricSpliceEditorWidget::performReferencedCheck()
+{
+  std::string nodeName = getCurrentNodeName();
+  if(nodeName.length() == 0)
+    return;
+  FabricSpliceBaseInterface * node = FabricSpliceBaseInterface::getInstanceByName(nodeName);
+  if(node == NULL)
+    return;
+
+  if(node->getSpliceGraph().isReferenced())
+  {
+    mSourceCode->setEnabled(false);
+    mAttrList->setEnabled(false);
+    mOperatorList->setEnabled(false);
+    mAddAttrButton->setEnabled(false);
+    mRemoveAttrButton->setEnabled(false);
+    mAddOpButton->setEnabled(false);
+    mEditOpButton->setEnabled(false);
+    mRemoveOpButton->setEnabled(false);
+    mCompileButton->setEnabled(false);
+  }
+  else
+  {
+    mSourceCode->setEnabled(!node->getSpliceGraph().isKLOperatorFileBased(mOpName.c_str()));
+    mAttrList->setEnabled(true);
+    mOperatorList->setEnabled(true);
+    mAddAttrButton->setEnabled(true);
+    mRemoveAttrButton->setEnabled(true);
+    mAddOpButton->setEnabled(true);
+    mEditOpButton->setEnabled(true);
+    mRemoveOpButton->setEnabled(true);
+    mCompileButton->setEnabled(true);
+  }
+}
+
 void FabricSpliceEditorWidget::onNodeChanged(void * userData)
 {
   MStatus status;
@@ -314,6 +349,8 @@ void FabricSpliceEditorWidget::onNodeChanged(void * userData)
     }
   }
 
+  editor->performReferencedCheck();
+
   MAYASPLICE_CATCH_END(&status);
 }
 
@@ -334,6 +371,8 @@ void FabricSpliceEditorWidget::onOperatorChanged(void * userData)
   editor->mSourceCode->setEnabled(!interf->getSpliceGraph().isKLOperatorFileBased(opName.c_str()));
   editor->mErrorLog->setText("");
   editor->mErrorLog->hide();
+
+  editor->performReferencedCheck();
 
   MAYASPLICE_CATCH_END(&status);
 }

--- a/FabricSpliceEditorWidget.h
+++ b/FabricSpliceEditorWidget.h
@@ -84,6 +84,7 @@ private:
 
   std::string getCurrentNodeName();
   FabricSpliceBaseInterface * getCurrentBaseInterface();
+  void performReferencedCheck();
 
 protected:
   virtual bool event ( QEvent * event );


### PR DESCRIPTION
@pzion: support for referenced splice files in maya. missing ports will be created, invalid ports will not be cleaned up. the users can query the port info in python / mel and clean up invalid maya attributes. we've chosen not to remove / change existing attributes with data type mismatches, since that would break the maya grahp eventually.